### PR TITLE
[feature/kkuleogi-3] API, 좋아요 API 구현

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/domain/repository/BookRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/domain/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package com.Familyship.checkkuleogi.domains.book.domain.repository;
+
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/Child.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/Child.java
@@ -1,6 +1,7 @@
 package com.Familyship.checkkuleogi.domains.child.domain;
 
 import com.Familyship.checkkuleogi.global.domain.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Getter;
 import com.Familyship.checkkuleogi.domains.user.domain.SiteUser;
@@ -25,8 +26,12 @@ public class Child extends BaseEntity {
     @Column(name = "child_mbti")
     private String mbti;
 
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "parent_id", referencedColumnName = "user_idx")
+//    private SiteUser parent;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id", referencedColumnName = "user_idx")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"}) // 부모 쪽도 적용
     private SiteUser parent;
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/repository/ChildRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/repository/ChildRepository.java
@@ -1,0 +1,7 @@
+package com.Familyship.checkkuleogi.domains.child.domain.repository;
+
+import com.Familyship.checkkuleogi.domains.child.domain.Child;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChildRepository extends JpaRepository<Child, Long> {
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -35,4 +35,9 @@ public class BookLike extends BaseEntity {
         this.book = book;
         this.likedislike = likedislike;
     }
+
+    //필요 시 Setter사용
+    public void setLikedislike(boolean likedislike) {
+        this.likedislike = likedislike;
+    }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -37,8 +37,7 @@ public class BookLike extends BaseEntity {
         this.likedislike = likedislike;
     }
 
-    //필요 시 Setter사용
-    public void setLikedislike(boolean likedislike) {
+    public void updateLikedislike(boolean likedislike) {
         this.likedislike = likedislike;
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -4,10 +4,7 @@ import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.global.domain.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -27,12 +27,12 @@ public class BookLike extends BaseEntity {
     private Book book;
 
     @Column(name = "is_like")
-    private boolean isLike;
+    private boolean likedislike;
 
     @Builder
-    public BookLike(Child child, Book book, boolean isLike) {
+    public BookLike(Child child, Book book, boolean likedislike) {
         this.child = child;
         this.book = book;
-        this.isLike = isLike;
+        this.likedislike = likedislike;
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -4,11 +4,17 @@ import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.global.domain.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "book_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "book_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"child_idx", "book_idx"})
+})
 public class BookLike extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,4 +31,11 @@ public class BookLike extends BaseEntity {
 
     @Column(name = "is_like")
     private boolean isLike;
+
+    @Builder
+    public BookLike(Child child, Book book, boolean isLike) {
+        this.child = child;
+        this.book = book;
+        this.isLike = isLike;
+    }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -3,6 +3,7 @@ package com.Familyship.checkkuleogi.domains.like.domain;
 import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.global.domain.BaseEntity;
+
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
@@ -1,8 +1,14 @@
 package com.Familyship.checkkuleogi.domains.like.domain.repository;
 
+import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BookLikeRepository extends JpaRepository<BookLike, Long> {
+
     boolean existsByChildIdxAndBookIdx(Long childIdx, Long bookIdx);
+
+    List<BookLike> findByChild(Child child);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
@@ -1,8 +1,8 @@
 package com.Familyship.checkkuleogi.domains.like.domain.repository;
 
-import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
@@ -1,10 +1,12 @@
 package com.Familyship.checkkuleogi.domains.like.domain.repository;
 
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookLikeRepository extends JpaRepository<BookLike, Long> {
 
@@ -13,4 +15,6 @@ public interface BookLikeRepository extends JpaRepository<BookLike, Long> {
     List<BookLike> findByChild(Child child);
 
     List<BookLike> findByChildAndLikedislike(Child child, boolean like);
+
+    Optional<BookLike> findByChildIdxAndBookIdx(Long childIdx, Long bookIdx);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
@@ -1,0 +1,8 @@
+package com.Familyship.checkkuleogi.domains.like.domain.repository;
+
+import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookLikeRepository extends JpaRepository<BookLike, Long> {
+    boolean existsByChildIdxAndBookIdx(Long childIdx, Long bookIdx);
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/repository/BookLikeRepository.java
@@ -11,4 +11,6 @@ public interface BookLikeRepository extends JpaRepository<BookLike, Long> {
     boolean existsByChildIdxAndBookIdx(Long childIdx, Long bookIdx);
 
     List<BookLike> findByChild(Child child);
+
+    List<BookLike> findByChildAndLikedislike(Child child, boolean like);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeDto.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeDto.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class LikeDto {
     private Long childIdx;
     private Long bookIdx;
-    private boolean isLike;
+    private boolean likedislike;
 }
 

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeDto.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeDto.java
@@ -1,0 +1,13 @@
+package com.Familyship.checkkuleogi.domains.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeDto {
+    private Long childIdx;
+    private Long bookIdx;
+    private boolean isLike;
+}
+

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeListResponseDto.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeListResponseDto.java
@@ -3,12 +3,11 @@ package com.Familyship.checkkuleogi.domains.like.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
-public class LikeDto {
-    private Long childIdx;
-    private Long bookIdx;
-    private boolean likedislike;
+public class LikeListResponseDto {
+    private List<LikeResponseDto> likes;
 }
-
 

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeResponseDto.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/dto/LikeResponseDto.java
@@ -5,10 +5,8 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class LikeDto {
+public class LikeResponseDto {
     private Long childIdx;
     private Long bookIdx;
     private boolean likedislike;
 }
-
-

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/exception/DuplicateLikeException.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/exception/DuplicateLikeException.java
@@ -1,0 +1,7 @@
+package com.Familyship.checkkuleogi.domains.like.exception;
+
+public class DuplicateLikeException extends RuntimeException{
+    public DuplicateLikeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -85,14 +85,14 @@ public class BookLikeController {
         return CommonResponseEntity.success(result);
     }
 
-    @PatchMapping("/change")
+    @PatchMapping("")
     public CommonResponseEntity<String> changeLikeDislike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
         bookLikeService.updateLike(childIdx, bookIdx);
         return CommonResponseEntity.success("좋아요 싫어요 변경 완료");
     }
 
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("")
     public CommonResponseEntity<String> deleteLike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
         bookLikeService.deleteLike(childIdx, bookIdx);
         return CommonResponseEntity.success("좋아요 싫어요 삭제 완료"); // 삭제가 성공했음을 나타냄

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -85,11 +85,12 @@ public class BookLikeController {
         return CommonResponseEntity.success(result);
     }
 
-    @PutMapping("/change")
+    @PatchMapping("/change")
     public CommonResponseEntity<String> changeLikeDislike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
         bookLikeService.updateLike(childIdx, bookIdx);
         return CommonResponseEntity.success("좋아요 싫어요 변경 완료");
     }
+
 
     @DeleteMapping("/delete")
     public CommonResponseEntity<String> deleteLike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -3,13 +3,21 @@ package com.Familyship.checkkuleogi.domains.like.presentation;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
 import com.Familyship.checkkuleogi.domains.like.service.BookLikeServcie;
+import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
 import com.Familyship.checkkuleogi.global.domain.response.CommonResponseEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 public class BookLikeController {
+
     private final BookLikeServcie bookLikeService;
 
     @PostMapping("/like")
@@ -25,4 +33,28 @@ public class BookLikeController {
         );
         return CommonResponseEntity.success(res);
     }
+
+    @GetMapping("/likedislike/{child_idx}")
+    public CommonResponseEntity<List<Map<String, Object>>> getLikeDislike(@PathVariable("child_idx") Long childIdx) {
+        List<BookLike> likedislike = bookLikeService.getLikeDislike(childIdx);
+
+        if (likedislike.isEmpty()) {
+            return CommonResponseEntity.error(null, HttpStatus.NOT_FOUND, "좋아요/싫어요 기록이 없습니다.");
+        }
+
+        List<Map<String, Object>> result = likedislike.stream()
+                .map(ld -> {
+                    Map<String, Object> res = new HashMap<>();
+                    res.put("book", Map.of(
+                            "id", ld.getBook().getIdx(),
+                            "title", ld.getBook().getTitle()
+                    ));
+                    res.put("like", ld.isLike());
+                    return res;
+                })
+                .collect(Collectors.toList());
+        return CommonResponseEntity.success(result);
+    }
+
+
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -4,7 +4,9 @@ import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
 import com.Familyship.checkkuleogi.domains.like.service.BookLikeService;
 import com.Familyship.checkkuleogi.global.domain.response.CommonResponseEntity;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,12 +16,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
+@RequestMapping("/likedislike")
 @RequiredArgsConstructor
 public class BookLikeController {
 
     private final BookLikeService bookLikeService;
 
-    @PostMapping("/like")
+    @PostMapping("")
     public CommonResponseEntity<LikeDto> createBookLike(@RequestParam Long childIdx,
                                                          @RequestParam Long bookIdx,
                                                          @RequestParam boolean isLike) {
@@ -33,7 +36,7 @@ public class BookLikeController {
         return CommonResponseEntity.success(res);
     }
 
-    @GetMapping("/likedislike/{child_idx}")
+    @GetMapping("/{child_idx}")
     public CommonResponseEntity<List<Map<String, Object>>> getLikeDislike(@PathVariable("child_idx") Long childIdx) {
         List<BookLike> likedislike = bookLikeService.getLikeDislike(childIdx);
 
@@ -55,7 +58,7 @@ public class BookLikeController {
         return CommonResponseEntity.success(result);
     }
 
-    @GetMapping("/onlylikes/{child_idx}")
+    @GetMapping("/only/{child_idx}")
     public CommonResponseEntity<List<Map<String, Object>>> getLikes(
             @PathVariable("child_idx") Long childIdx,
             @RequestParam boolean isLike) {
@@ -82,13 +85,13 @@ public class BookLikeController {
         return CommonResponseEntity.success(result);
     }
 
-    @PutMapping("/likedislike/change")
+    @PutMapping("/change")
     public CommonResponseEntity<String> changeLikeDislike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
         bookLikeService.updateLike(childIdx, bookIdx);
         return CommonResponseEntity.success("좋아요 싫어요 변경 완료");
     }
 
-    @DeleteMapping("/likedislike/delete")
+    @DeleteMapping("/delete")
     public CommonResponseEntity<String> deleteLike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
         bookLikeService.deleteLike(childIdx, bookIdx);
         return CommonResponseEntity.success("좋아요 싫어요 삭제 완료"); // 삭제가 성공했음을 나타냄

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -1,100 +1,53 @@
 package com.Familyship.checkkuleogi.domains.like.presentation;
 
-import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeListResponseDto;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeResponseDto;
+
 import com.Familyship.checkkuleogi.domains.like.service.BookLikeService;
 import com.Familyship.checkkuleogi.global.domain.response.CommonResponseEntity;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("api/v1/likedislike")
+@RequestMapping("api/v1/like")
 @RequiredArgsConstructor
 public class BookLikeController {
 
     private final BookLikeService bookLikeService;
 
     @PostMapping("")
-    public CommonResponseEntity<LikeDto> createBookLike(@RequestParam Long childIdx,
-                                                         @RequestParam Long bookIdx,
-                                                         @RequestParam boolean isLike) {
-        BookLike bookLike = bookLikeService.createLike(childIdx, bookIdx, isLike);
-
-        LikeDto res = new LikeDto(
-                bookLike.getChild().getIdx(),
-                bookLike.getBook().getIdx(),
-                bookLike.isLikedislike()
-        );
-        return CommonResponseEntity.success(res);
+    public CommonResponseEntity<LikeResponseDto> createBookLike(@RequestBody LikeDto dto) {
+        return CommonResponseEntity.success(bookLikeService.createLike(dto));
     }
 
     @GetMapping("/{child_idx}")
-    public CommonResponseEntity<List<Map<String, Object>>> getLikeDislike(@PathVariable("child_idx") Long childIdx) {
-        List<BookLike> likedislike = bookLikeService.getLikeDislike(childIdx);
-
-        if (likedislike.isEmpty()) {
-            return CommonResponseEntity.error(null, HttpStatus.NOT_FOUND, "좋아요/싫어요 기록이 없습니다.");
-        }
-
-        List<Map<String, Object>> result = likedislike.stream()
-                .map(ld -> {
-                    Map<String, Object> res = new HashMap<>();
-                    res.put("book", Map.of(
-                            "book_idx", ld.getBook().getIdx(),
-                            "title", ld.getBook().getTitle()
-                    ));
-                    res.put("like", ld.isLikedislike());
-                    return res;
-                })
-                .collect(Collectors.toList());
-        return CommonResponseEntity.success(result);
+    public CommonResponseEntity<LikeListResponseDto> getLikeDislike(@PathVariable("child_idx") Long childIdx) {
+        return CommonResponseEntity.success(bookLikeService.getLikeDislike(childIdx));
     }
 
-    @GetMapping("/only/{child_idx}")
-    public CommonResponseEntity<List<Map<String, Object>>> getLikes(
-            @PathVariable("child_idx") Long childIdx,
-            @RequestParam boolean isLike) {
-        List<BookLike> likes = bookLikeService.getLikesDislikes(childIdx, isLike);
+    @GetMapping("/likes/{child_idx}")
+    public CommonResponseEntity<LikeListResponseDto> getLikes(@PathVariable("child_idx") Long childIdx) {
+        return CommonResponseEntity.success(bookLikeService.getLikes(childIdx));
+    }
 
-        if (likes.isEmpty()) {
-            if(isLike) {
-                return CommonResponseEntity.error(null, HttpStatus.NOT_FOUND, "좋아요 기록이 없습니다.");
-            }else{
-                return CommonResponseEntity.error(null, HttpStatus.NOT_FOUND, "싫어요 기록이 없습니다.");
-            }
-
-        }
-        List<Map<String, Object>> result = likes.stream()
-                .map(like -> {
-                    Map<String, Object> res = new HashMap<>();
-                    res.put("book", Map.of(
-                            "book_idx", like.getBook().getIdx(),
-                            "title", like.getBook().getTitle()
-                    ));
-                    return res;
-                })
-                .collect(Collectors.toList());
-        return CommonResponseEntity.success(result);
+    @GetMapping("/dislikes/{child_idx}")
+    public CommonResponseEntity<LikeListResponseDto> getDislikes(@PathVariable("child_idx") Long childIdx) {
+        return CommonResponseEntity.success(bookLikeService.getDislikes(childIdx));
     }
 
     @PatchMapping("")
-    public CommonResponseEntity<String> changeLikeDislike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
-        bookLikeService.updateLike(childIdx, bookIdx);
+    public CommonResponseEntity<String> changeLikeDislike(@RequestBody LikeDto dto) {
+        bookLikeService.updateLike(dto);
         return CommonResponseEntity.success("좋아요 싫어요 변경 완료");
     }
 
-
     @DeleteMapping("")
-    public CommonResponseEntity<String> deleteLike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
-        bookLikeService.deleteLike(childIdx, bookIdx);
-        return CommonResponseEntity.success("좋아요 싫어요 삭제 완료"); // 삭제가 성공했음을 나타냄
+    public CommonResponseEntity<String> deleteLikeDisLike(@RequestBody LikeDto dto) {
+        bookLikeService.deleteLike(dto);
+        return CommonResponseEntity.success("좋아요 싫어요 삭제 완료");
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -1,0 +1,28 @@
+package com.Familyship.checkkuleogi.domains.like.presentation;
+
+import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
+import com.Familyship.checkkuleogi.domains.like.service.BookLikeServcie;
+import com.Familyship.checkkuleogi.global.domain.response.CommonResponseEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class BookLikeController {
+    private final BookLikeServcie bookLikeService;
+
+    @PostMapping("/like")
+    public CommonResponseEntity<LikeDto> createBookLike(@RequestParam Long childIdx,
+                                                         @RequestParam Long bookIdx,
+                                                         @RequestParam boolean isLike) {
+        BookLike bookLike = bookLikeService.createLike(childIdx, bookIdx, isLike);
+
+        LikeDto res = new LikeDto(
+                bookLike.getChild().getIdx(),
+                bookLike.getBook().getIdx(),
+                bookLike.isLike()
+        );
+        return CommonResponseEntity.success(res);
+    }
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -87,4 +87,10 @@ public class BookLikeController {
         bookLikeService.updateLike(childIdx, bookIdx);
         return CommonResponseEntity.success("좋아요 싫어요 변경 완료");
     }
+
+    @DeleteMapping("/likedislike/delete")
+    public CommonResponseEntity<String> deleteLike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
+        bookLikeService.deleteLike(childIdx, bookIdx);
+        return CommonResponseEntity.success("좋아요 싫어요 삭제 완료"); // 삭제가 성공했음을 나타냄
+    }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/likedislike")
+@RequestMapping("api/v1/likedislike")
 @RequiredArgsConstructor
 public class BookLikeController {
 

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/presentation/BookLikeController.java
@@ -3,7 +3,6 @@ package com.Familyship.checkkuleogi.domains.like.presentation;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
 import com.Familyship.checkkuleogi.domains.like.service.BookLikeService;
-import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
 import com.Familyship.checkkuleogi.global.domain.response.CommonResponseEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -81,5 +80,11 @@ public class BookLikeController {
                 })
                 .collect(Collectors.toList());
         return CommonResponseEntity.success(result);
+    }
+
+    @PutMapping("/likedislike/change")
+    public CommonResponseEntity<String> changeLikeDislike(@RequestParam Long childIdx, @RequestParam Long bookIdx) {
+        bookLikeService.updateLike(childIdx, bookIdx);
+        return CommonResponseEntity.success("좋아요 싫어요 변경 완료");
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeServcie.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeServcie.java
@@ -11,6 +11,8 @@ import com.Familyship.checkkuleogi.domains.like.exception.DuplicateLikeException
 import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class BookLikeServcie {
     private final BookLikeRepository bookLikeRepository;
@@ -42,5 +44,11 @@ public class BookLikeServcie {
                 .build();
 
         return bookLikeRepository.save(bookLike);
+    }
+
+    public List<BookLike> getLikeDislike(Long childIdx){
+        Child child = childRepository.findById(childIdx)
+                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
+        return bookLikeRepository.findByChild(child);
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeServcie.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeServcie.java
@@ -1,0 +1,46 @@
+package com.Familyship.checkkuleogi.domains.like.service;
+
+
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
+import com.Familyship.checkkuleogi.domains.book.domain.repository.BookRepository;
+import com.Familyship.checkkuleogi.domains.child.domain.Child;
+import com.Familyship.checkkuleogi.domains.child.domain.repository.ChildRepository;
+import com.Familyship.checkkuleogi.domains.like.domain.repository.BookLikeRepository;
+import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
+import com.Familyship.checkkuleogi.domains.like.exception.DuplicateLikeException;
+import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookLikeServcie {
+    private final BookLikeRepository bookLikeRepository;
+    private final ChildRepository childRepository;
+    private final BookRepository bookRepository;
+
+    public BookLikeServcie(BookLikeRepository bookLikeRepository, ChildRepository childRepository, BookRepository bookRepository) {
+        this.bookLikeRepository = bookLikeRepository;
+        this.childRepository = childRepository;
+        this.bookRepository = bookRepository;
+    }
+
+    public BookLike createLike(Long childIdx, Long bookIdx, boolean isLike) {
+        //중복 검증
+        if(bookLikeRepository.existsByChildIdxAndBookIdx(childIdx, bookIdx)) {
+            throw new DuplicateLikeException("이미 좋아요/싫어요를 눌렀습니다.");
+        }
+        //존재하는 Child인가?
+        Child child = childRepository.findById(childIdx)
+                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
+        //존재하는 Book인가?
+        Book book = bookRepository.findById(bookIdx)
+                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
+
+        BookLike bookLike = BookLike.builder()
+                .child(child)
+                .book(book)
+                .isLike(isLike)
+                .build();
+
+        return bookLikeRepository.save(bookLike);
+    }
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
@@ -1,14 +1,15 @@
 package com.Familyship.checkkuleogi.domains.like.service;
 
-
 import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.book.domain.repository.BookRepository;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.domains.child.domain.repository.ChildRepository;
 import com.Familyship.checkkuleogi.domains.like.domain.repository.BookLikeRepository;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
+
 import com.Familyship.checkkuleogi.domains.like.exception.DuplicateLikeException;
 import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
+
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -69,7 +70,7 @@ public class BookLikeService {
                 .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
 
         BookLike existbookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
-                .orElseThrow(() -> new NotFoundException("좋아요 기록을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("좋아요/싫어요 기록을 찾을 수 없습니다."));
 
         // 좋아요/싫어요 상태 변경
         boolean newLikeDislike = !existbookLike.isLikedislike();
@@ -88,7 +89,7 @@ public class BookLikeService {
                 .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
 
         BookLike bookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
-                .orElseThrow(() -> new NotFoundException("좋아요 기록을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("좋아요/싫어요 기록을 찾을 수 없습니다."));
 
         // 좋아요/싫어요 삭제
         bookLikeRepository.delete(bookLike);

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
@@ -1,97 +1,22 @@
 package com.Familyship.checkkuleogi.domains.like.service;
 
-import com.Familyship.checkkuleogi.domains.book.domain.Book;
-import com.Familyship.checkkuleogi.domains.book.domain.repository.BookRepository;
-import com.Familyship.checkkuleogi.domains.child.domain.Child;
-import com.Familyship.checkkuleogi.domains.child.domain.repository.ChildRepository;
-import com.Familyship.checkkuleogi.domains.like.domain.repository.BookLikeRepository;
-import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 
-import com.Familyship.checkkuleogi.domains.like.exception.DuplicateLikeException;
-import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeListResponseDto;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeResponseDto;
 
-import org.springframework.stereotype.Service;
+public interface BookLikeService {
 
-import java.util.List;
+    LikeResponseDto createLike(LikeDto dto);
 
-@Service
-public class BookLikeService {
-    private final BookLikeRepository bookLikeRepository;
-    private final ChildRepository childRepository;
-    private final BookRepository bookRepository;
+    LikeListResponseDto getLikeDislike(Long childIdx);
 
-    public BookLikeService(BookLikeRepository bookLikeRepository, ChildRepository childRepository, BookRepository bookRepository) {
-        this.bookLikeRepository = bookLikeRepository;
-        this.childRepository = childRepository;
-        this.bookRepository = bookRepository;
-    }
+    LikeListResponseDto getLikes(Long childIdx);
 
-    public BookLike createLike(Long childIdx, Long bookIdx, boolean isLike) {
-        //중복 검증
-        if(bookLikeRepository.existsByChildIdxAndBookIdx(childIdx, bookIdx)) {
-            throw new DuplicateLikeException("이미 좋아요/싫어요를 눌렀습니다.");
-        }
-        //존재하는 Child인가?
-        Child child = childRepository.findById(childIdx)
-                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
-        //존재하는 Book인가?
-        Book book = bookRepository.findById(bookIdx)
-                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
+    LikeListResponseDto getDislikes(Long childIdx);
 
-        BookLike bookLike = BookLike.builder()
-                .child(child)
-                .book(book)
-                .likedislike(isLike)
-                .build();
+    void updateLike(LikeDto dto);
 
-        return bookLikeRepository.save(bookLike);
-    }
+    void deleteLike(LikeDto dto);
 
-    //전체 목록 조회
-    public List<BookLike> getLikeDislike(Long childIdx){
-        Child child = childRepository.findById(childIdx)
-                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
-        return bookLikeRepository.findByChild(child);
-    }
-
-    //좋아요만 & 싫어요만 조회
-    public List<BookLike> getLikesDislikes(Long childIdx, boolean isLike) {
-        Child child = childRepository.findById(childIdx)
-                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
-        return bookLikeRepository.findByChildAndLikedislike(child, isLike);
-    }
-
-    //좋아요 -> 싫어요 or 싫어요 -> 좋아요
-    public void updateLike(Long childIdx, Long bookIdx) {
-        childRepository.findById(childIdx)
-                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
-
-        bookRepository.findById(bookIdx)
-                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
-
-        BookLike existbookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
-                .orElseThrow(() -> new NotFoundException("좋아요/싫어요 기록을 찾을 수 없습니다."));
-
-        // 좋아요/싫어요 상태 변경
-        boolean newLikeDislike = !existbookLike.isLikedislike();
-
-        existbookLike.setLikedislike(newLikeDislike);
-
-        bookLikeRepository.save(existbookLike);
-    }
-
-    //삭제
-    public void deleteLike(Long childIdx, Long bookIdx) {
-        childRepository.findById(childIdx)
-                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
-
-        bookRepository.findById(bookIdx)
-                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
-
-        BookLike bookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
-                .orElseThrow(() -> new NotFoundException("좋아요/싫어요 기록을 찾을 수 없습니다."));
-
-        // 좋아요/싫어요 삭제
-        bookLikeRepository.delete(bookLike);
-    }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
@@ -14,12 +14,12 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class BookLikeServcie {
+public class BookLikeService {
     private final BookLikeRepository bookLikeRepository;
     private final ChildRepository childRepository;
     private final BookRepository bookRepository;
 
-    public BookLikeServcie(BookLikeRepository bookLikeRepository, ChildRepository childRepository, BookRepository bookRepository) {
+    public BookLikeService(BookLikeRepository bookLikeRepository, ChildRepository childRepository, BookRepository bookRepository) {
         this.bookLikeRepository = bookLikeRepository;
         this.childRepository = childRepository;
         this.bookRepository = bookRepository;
@@ -40,7 +40,7 @@ public class BookLikeServcie {
         BookLike bookLike = BookLike.builder()
                 .child(child)
                 .book(book)
-                .isLike(isLike)
+                .likedislike(isLike)
                 .build();
 
         return bookLikeRepository.save(bookLike);
@@ -50,5 +50,11 @@ public class BookLikeServcie {
         Child child = childRepository.findById(childIdx)
                 .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
         return bookLikeRepository.findByChild(child);
+    }
+
+    public List<BookLike> getLikesDislikes(Long childIdx, boolean isLike){
+        Child child = childRepository.findById(childIdx)
+                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
+        return bookLikeRepository.findByChildAndLikedislike(child, isLike);
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
@@ -46,15 +46,37 @@ public class BookLikeService {
         return bookLikeRepository.save(bookLike);
     }
 
+    //전체 목록 조회
     public List<BookLike> getLikeDislike(Long childIdx){
         Child child = childRepository.findById(childIdx)
                 .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
         return bookLikeRepository.findByChild(child);
     }
 
-    public List<BookLike> getLikesDislikes(Long childIdx, boolean isLike){
+    //좋아요만 & 싫어요만 조회
+    public List<BookLike> getLikesDislikes(Long childIdx, boolean isLike) {
         Child child = childRepository.findById(childIdx)
                 .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
         return bookLikeRepository.findByChildAndLikedislike(child, isLike);
+    }
+
+    //좋아요 -> 싫어요 or 싫어요 -> 좋아요
+    public void updateLike(Long childIdx, Long bookIdx) {
+        Child child = childRepository.findById(childIdx)
+                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
+
+        Book book = bookRepository.findById(bookIdx)
+                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
+
+        BookLike existbookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
+                .orElseThrow(() -> new NotFoundException("좋아요 기록을 찾을 수 없습니다."));
+
+        // 좋아요/싫어요 상태 변경
+        System.out.println(existbookLike.getBook().getIdx()+"asdffdasdffsda");
+        boolean newLikeDislike = !existbookLike.isLikedislike();
+
+        existbookLike.setLikedislike(newLikeDislike);
+
+        bookLikeRepository.save(existbookLike);
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeService.java
@@ -62,21 +62,35 @@ public class BookLikeService {
 
     //좋아요 -> 싫어요 or 싫어요 -> 좋아요
     public void updateLike(Long childIdx, Long bookIdx) {
-        Child child = childRepository.findById(childIdx)
+        childRepository.findById(childIdx)
                 .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
 
-        Book book = bookRepository.findById(bookIdx)
+        bookRepository.findById(bookIdx)
                 .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
 
         BookLike existbookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
                 .orElseThrow(() -> new NotFoundException("좋아요 기록을 찾을 수 없습니다."));
 
         // 좋아요/싫어요 상태 변경
-        System.out.println(existbookLike.getBook().getIdx()+"asdffdasdffsda");
         boolean newLikeDislike = !existbookLike.isLikedislike();
 
         existbookLike.setLikedislike(newLikeDislike);
 
         bookLikeRepository.save(existbookLike);
+    }
+
+    //삭제
+    public void deleteLike(Long childIdx, Long bookIdx) {
+        childRepository.findById(childIdx)
+                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
+
+        bookRepository.findById(bookIdx)
+                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
+
+        BookLike bookLike = bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
+                .orElseThrow(() -> new NotFoundException("좋아요 기록을 찾을 수 없습니다."));
+
+        // 좋아요/싫어요 삭제
+        bookLikeRepository.delete(bookLike);
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeServiceImpl.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/service/BookLikeServiceImpl.java
@@ -1,0 +1,140 @@
+package com.Familyship.checkkuleogi.domains.like.service;
+
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
+import com.Familyship.checkkuleogi.domains.book.domain.repository.BookRepository;
+import com.Familyship.checkkuleogi.domains.child.domain.Child;
+import com.Familyship.checkkuleogi.domains.child.domain.repository.ChildRepository;
+import com.Familyship.checkkuleogi.domains.like.domain.repository.BookLikeRepository;
+import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
+
+import com.Familyship.checkkuleogi.domains.like.dto.LikeDto;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeResponseDto;
+import com.Familyship.checkkuleogi.domains.like.dto.LikeListResponseDto;
+
+import com.Familyship.checkkuleogi.domains.like.exception.DuplicateLikeException;
+import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BookLikeServiceImpl implements BookLikeService{
+    private final BookLikeRepository bookLikeRepository;
+    private final ChildRepository childRepository;
+    private final BookRepository bookRepository;
+
+    public BookLikeServiceImpl(BookLikeRepository bookLikeRepository, ChildRepository childRepository, BookRepository bookRepository) {
+        this.bookLikeRepository = bookLikeRepository;
+        this.childRepository = childRepository;
+        this.bookRepository = bookRepository;
+    }
+
+    // 좋아요/싫어요 생성
+    public LikeResponseDto createLike(LikeDto dto) {
+        // 중복 검증
+        if (bookLikeRepository.existsByChildIdxAndBookIdx(dto.getChildIdx(), dto.getBookIdx())) {
+            throw new DuplicateLikeException("이미 좋아요/싫어요를 눌렀습니다.");
+        }
+
+        Child child = findChildById(dto.getChildIdx());
+        Book book = findBookById(dto.getBookIdx());
+
+        BookLike bookLike = BookLike.builder()
+                .child(child)
+                .book(book)
+                .likedislike(dto.isLikedislike())
+                .build();
+        bookLikeRepository.save(bookLike);
+
+        return new LikeResponseDto(
+                bookLike.getChild().getIdx(),
+                bookLike.getBook().getIdx(),
+                bookLike.isLikedislike()
+        );
+    }
+
+    // 좋아요/싫어요 전체 목록 조회
+    public LikeListResponseDto getLikeDislike(Long childIdx) {
+        Child child = findChildById(childIdx);
+        List<BookLike> likedislike = bookLikeRepository.findByChild(child);
+
+        if (likedislike.isEmpty()) {
+            throw new NotFoundException("좋아요/싫어요 기록이 없습니다.");
+        }
+
+        List<LikeResponseDto> responseList = likedislike.stream()
+                .map(ld -> new LikeResponseDto(ld.getChild().getIdx(), ld.getBook().getIdx(), ld.isLikedislike()))
+                .collect(Collectors.toList());
+
+        return new LikeListResponseDto(responseList);
+    }
+
+    //좋아요만
+    public LikeListResponseDto getLikes(Long childIdx) {
+        Child child = findChildById(childIdx);
+        List<BookLike> likes = bookLikeRepository.findByChildAndLikedislike(child, true);
+
+        if (likes.isEmpty()) {
+            throw new NotFoundException("좋아요 기록이 없습니다.");
+        }
+
+        List<LikeResponseDto> responseList = likes.stream()
+                .map(like -> new LikeResponseDto(like.getChild().getIdx(), like.getBook().getIdx(), like.isLikedislike()))
+                .collect(Collectors.toList());
+
+        return new LikeListResponseDto(responseList);
+    }
+
+    //싫어요만
+    public LikeListResponseDto getDislikes(Long childIdx) {
+        Child child = findChildById(childIdx);
+        List<BookLike> likes = bookLikeRepository.findByChildAndLikedislike(child, false);
+
+        if (likes.isEmpty()) {
+            throw new NotFoundException("싫어요 기록이 없습니다.");
+        }
+
+        List<LikeResponseDto> responseList = likes.stream()
+                .map(like -> new LikeResponseDto(like.getChild().getIdx(), like.getBook().getIdx(), like.isLikedislike()))
+                .collect(Collectors.toList());
+
+        return new LikeListResponseDto(responseList);
+    }
+
+
+    // 좋아요 -> 싫어요 or 싫어요 -> 좋아요
+    public void updateLike(LikeDto dto) {
+        BookLike existbookLike = findBookLikeByChildAndBook(dto.getChildIdx(), dto.getBookIdx());
+
+        boolean newLikeDislike = !existbookLike.isLikedislike();
+        existbookLike.updateLikedislike(newLikeDislike);
+
+        bookLikeRepository.save(existbookLike);
+    }
+
+    // 좋아요/싫어요 삭제
+    public void deleteLike(LikeDto dto) {
+        BookLike bookLike = findBookLikeByChildAndBook(dto.getChildIdx(), dto.getBookIdx());
+        bookLikeRepository.delete(bookLike);
+    }
+
+    // Child 조회
+    private Child findChildById(Long childIdx) {
+        return childRepository.findById(childIdx)
+                .orElseThrow(() -> new NotFoundException("어린이를 찾을 수 없습니다."));
+    }
+
+    // Book 조회
+    private Book findBookById(Long bookIdx) {
+        return bookRepository.findById(bookIdx)
+                .orElseThrow(() -> new NotFoundException("책을 찾을 수 없습니다."));
+    }
+
+    // BookLike 조회
+    private BookLike findBookLikeByChildAndBook(Long childIdx, Long bookIdx) {
+        return bookLikeRepository.findByChildIdxAndBookIdx(childIdx, bookIdx)
+                .orElseThrow(() -> new NotFoundException("좋아요/싫어요 기록을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/user/domain/SiteUser.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/user/domain/SiteUser.java
@@ -40,6 +40,6 @@ public class SiteUser extends BaseEntity {
     @Column(name = "user_role")
     private Role role;
 
-    @OneToMany(mappedBy = "parent")
-    private List<Child> children;
+//    @OneToMany(mappedBy = "parent")
+//    private List<Child> children;
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - 

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?
    - 좋아요 싫어요 Create
    - 좋아요 싫어요 전체 조회
    - 좋아요당 싫어요당 각자 전체 조회
    - 좋아요 -> 싫어요 or 싫어요 -> 좋아요 변경
    - 좋아요/싫어요 기록 삭제(취소)
     
    - 작업 내용 정리 : https://www.notion.so/981021/11c2efd96e6981e8bdd4dfd62a350c9f?v=11c2efd96e698159ae32000c5497c354
[좋아요싫어요 구현.docx](https://github.com/user-attachments/files/17404846/default.docx)


> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
    - 미리 child, book에 데이터 세팅 후 작업이 필요합니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : Yes
    - isLike 이름을 likedislike로 변경
    - 이유 : is는 JavaBeans규약에 따라 boolean타입 필드를 나타내는 일반적인 방법으로 이미 쓰이고 있어서 JPA에서 읽어들이지 못함 -> 엔티티명을 likedislike로 변경함

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
