### PR TITLE
[feature/kkuleogi-20] 휴면유저 isActive 분기, 벌크 연산(배치)

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/CheckkuleogiApplication.java
+++ b/src/main/java/com/Familyship/checkkuleogi/CheckkuleogiApplication.java
@@ -2,8 +2,10 @@ package com.Familyship.checkkuleogi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CheckkuleogiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -16,11 +17,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BookCacheManager {
 
+    public static final String LIST_KEY_SUFFIX = "recently_viewed_books";
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper; // Jackson ObjectMapper
 
     public Optional<List<BookCachingItem>> findBookListBy(Long childIdx) {
-        String listKey = "child:" + childIdx + ":recently_viewed_books";
+        String listKey = "child:" + childIdx + ":" + LIST_KEY_SUFFIX;
         List<String> cachedItems = redisTemplate.opsForList().range(listKey, 0, -1);
 
         if (cachedItems == null || cachedItems.isEmpty()) {
@@ -35,7 +37,7 @@ public class BookCacheManager {
     }
 
     public void cacheRecentlyViewedBook(BookCachingItem bookCachingItem, Long childIdx) {
-        String listKey = "child:" + childIdx + ":recently_viewed_books";
+        String listKey = "child:" + childIdx + ":" + LIST_KEY_SUFFIX;
         String newBookJson;
         // DTO를 JSON으로 직렬화하여 리스트에 저장
         try {
@@ -62,5 +64,9 @@ public class BookCacheManager {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error deserializing BookCachingItem", e);
         }
+    }
+
+    public Set<String> getRecentlyViewedBookKeys() {
+        return redisTemplate.keys("child:*:" + LIST_KEY_SUFFIX);
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/Child.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/Child.java
@@ -36,6 +36,9 @@ public class Child extends BaseEntity {
     @Column(name = "child_mbti")
     private String mbti;
 
+    @Column(name = "is_active")
+    private boolean isActive;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id", referencedColumnName = "user_idx")
     private SiteUser parent;

--- a/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/repository/ChildRepository.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/child/domain/repository/ChildRepository.java
@@ -2,9 +2,23 @@ package com.Familyship.checkkuleogi.domains.child.domain.repository;
 
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface ChildRepository extends JpaRepository<Child, Long> {
     Optional<Child> findByName(String name);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Child c SET c.isActive = true WHERE c.idx IN :activeUserIds")
+    void markUsersAsActive(Set<Long> activeUserIds);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Child c SET c.isActive = false WHERE c.idx NOT IN :activeUserIds")
+    void markUsersAsInactiveNotIn(Set<Long> activeUserIds);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/child/implementation/InactiveUserBatchJob.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/child/implementation/InactiveUserBatchJob.java
@@ -1,0 +1,35 @@
+package com.Familyship.checkkuleogi.domains.child.implementation;
+
+import com.Familyship.checkkuleogi.domains.book.implementation.BookCacheManager;
+import com.Familyship.checkkuleogi.domains.child.domain.repository.ChildRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class InactiveUserBatchJob {
+
+    private final ChildRepository childRepository;
+    private final BookCacheManager bookCacheManager;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 1 * *")
+    public void updateUserActivityStatus() {
+        // 최근 본 책 목록을 가진 유저의 ID 추출
+        Set<String> keys = bookCacheManager.getRecentlyViewedBookKeys();
+
+        Set<Long> activeUserIds = keys.stream()
+                .map(key -> Long.parseLong(key.split(":")[1]))
+                .collect(Collectors.toSet());
+
+        childRepository.markUsersAsActive(activeUserIds); // 활성 유저 업데이트
+        childRepository.markUsersAsInactiveNotIn(activeUserIds); // 비활성 유저 업데이트
+    }
+}


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 최근 한달 이내 책 조회 이력이 캐시에 없는 유저는 휴먼유저 처리, 이때 벌크 연산으로 배치 작업 수행
    - 만명의 child 더미 데이터로 테스트 완료. 배치작업 평균 250ms 소요 확인 완료

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 현재 Modifying어노테이션을 통해 손쉽게 배치 작업을 하고 있는데, 스프링 배치로의 기술 스택 전환 고려 필요

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : YES (Child isActive 필드 추가)

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
