### PR TITLE
[feature/kkuleogi-25] MBTI로직 수정

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/domains/child/service/ChildServiceImpl.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/child/service/ChildServiceImpl.java
@@ -37,42 +37,43 @@ public class ChildServiceImpl implements ChildService {
         // MBTI 설정 로직
         for (int i = 0; i < length; i++) {
             if (i == 0) { // 1번 문항 - E & I
-                if (arr[i] == 1) { // yes - E 성향
-                    mbtiPercent[i] = 50;
+                if (arr[i] > 0) { // yes - E 성향
+                    mbtiPercent[i] = 100-Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue(); // E 성향 비율 계산
                     mbtiResult += "E";
-                } else if (arr[i] == 2) { // no - I 성향
-                    mbtiPercent[i] = -50;
+                } else if (arr[i] < 0) { // no - I 성향
+                    mbtiPercent[i] = Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue(); // I 성향 비율 계산
                     mbtiResult += "I";
                 }
+
+
             } else if (i == 1) { // 2번 문항 - S & N
-                if (arr[i] == 1) { // yes - S 성향
-                    mbtiPercent[i] = 50;
+                if (arr[i] > 0) { // yes - S 성향
+                    mbtiPercent[i] = 100-Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue();
                     mbtiResult += "S";
-                } else if (arr[i] == 2) { // no - N 성향
-                    mbtiPercent[i] = -50;
+                } else if (arr[i] < 0) { // no - N 성향
+                    mbtiPercent[i] = Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue();
                     mbtiResult += "N";
                 }
             } else if (i == 2) { // 3번 문항 - T & F
-                if (arr[i] == 1) { // yes - T 성향
-                    mbtiPercent[i] = 50;
+                if (arr[i] > 0) { // yes - T 성향
+                    mbtiPercent[i] = 100-Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue();
                     mbtiResult += "T";
-                } else if (arr[i] == 2) { // no - F성향
-                    mbtiPercent[i] = -50;
+                } else if (arr[i] < 0) { // no - F성향
+                    mbtiPercent[i] = Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue();
                     mbtiResult += "F";
                 }
             } else if (i == 3) { // 4번 문항 - J & P
-                if (arr[i] == 1) { // yes - J 성향
-                    mbtiPercent[i] = 50;
+                if (arr[i] > 0) { // yes - J 성향
+                    mbtiPercent[i] = 100-Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue();
                     mbtiResult += "J";
-                } else if (arr[i] == 2) { // no - P 성향
-                    mbtiPercent[i] = -50;
+                } else if (arr[i] < 0) { // no - P 성향
+                    mbtiPercent[i] = Long.valueOf(Math.round((Math.abs(arr[i]) / 3.0) * 100)).intValue();
                     mbtiResult += "P";
                 }
             }
         }
         return mbtiResult;
     }
-
     @Transactional
     @Override
     public CreateChildResponseMbtiDTO createMBTI(CreateChildRequestMbtiDTO createChildRequestMBTIDTO) {


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : 
    - [Notion-API] : 

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - MBTI로직 수정
    - mbti진단 질문은 총 12개로 점수 범위는 -3~+3 이 됩니다.
    - 음수라면 I, N, F, P 이고 양수라면 E, S, T, J입니다.
    - 기존 mbti저장에는 50, -50만 저장되도록 되어있었는데 이를 비율 계산으로 저장되게 했습니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
    - mbti 계산 로직에 대한 의문이나 다른 아이디어가 있다면 말씀해주세요.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
