### PR TITLE
[feature/kkuleogi-22] BookService 계층 구조 분리 (BookAdminService, BookUserService 수평확장)

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/domain/enums/MBTIKeywords.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/domain/enums/MBTIKeywords.java
@@ -1,4 +1,4 @@
-package com.Familyship.checkkuleogi.domains.book.service;
+package com.Familyship.checkkuleogi.domains.book.domain.enums;
 
 //MBTI별 키워드
 public class MBTIKeywords {

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/GPTManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/GPTManager.java
@@ -3,7 +3,7 @@ package com.Familyship.checkkuleogi.domains.book.implementation;
 import com.Familyship.checkkuleogi.domains.book.dto.request.BookMBTIRequest;
 import com.Familyship.checkkuleogi.domains.book.dto.request.ChatGPTRequest;
 import com.Familyship.checkkuleogi.domains.book.dto.response.ChatGPTResponse;
-import com.Familyship.checkkuleogi.domains.book.service.MBTIKeywords;
+import com.Familyship.checkkuleogi.domains.book.domain.enums.MBTIKeywords;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/presentation/BookController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/presentation/BookController.java
@@ -20,21 +20,22 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:3000") // React 앱의 URL을 허용
 public class BookController {
 
-    private final BookService bookService;
+    private final BookService bookAdminService;
+    private final BookService bookUserService;
 
     @GetMapping("")
     public CommonResponseEntity<List<BookResponse>> getAllBooks() {
-        return success(bookService.getAllBooks());
+        return success(bookAdminService.getAllBooks());
     }
 
     @PostMapping("/admin")
     public CommonResponseEntity<BookResponse> createBook(@RequestBody BookMBTIRequest req) {
-        return success(bookService.createBook(req));
+        return success(bookAdminService.createBook(req));
     }
 
     @DeleteMapping("/admin/{bookId}")
     public CommonResponseEntity<String> deleteBook(@PathVariable Long bookId) {
-        bookService.deleteBookById(bookId);
+        bookAdminService.deleteBookById(bookId);
         return success("삭제 완료");
     }
 

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookAdminService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookAdminService.java
@@ -1,0 +1,41 @@
+package com.Familyship.checkkuleogi.domains.book.service;
+
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
+import com.Familyship.checkkuleogi.domains.book.dto.request.BookMBTIRequest;
+import com.Familyship.checkkuleogi.domains.book.dto.request.BookUpdateRequest;
+import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
+import com.Familyship.checkkuleogi.domains.book.implementation.BookAdminManager;
+import com.Familyship.checkkuleogi.domains.book.implementation.BookManager;
+import com.Familyship.checkkuleogi.domains.book.implementation.mapper.BookDtoMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+public class BookAdminService extends BookServiceImpl {
+
+    private BookDtoMapper bookDtoMapper;
+    private BookManager bookManager;
+    private BookAdminManager bookAdminManager;
+
+    public BookAdminService(BookDtoMapper bookDtoMapper, BookManager bookManager, BookAdminManager bookAdminManager) {
+        super(bookDtoMapper, bookManager, bookAdminManager);
+    }
+
+    @Transactional
+    public BookResponse createBook(BookMBTIRequest req) {
+        Book book = bookAdminManager.createBook(req);
+        return bookDtoMapper.toBookResp(book);
+    }
+
+    @Transactional
+    public void deleteBookById(Long bookId) {
+        bookAdminManager.deleteBook(bookId);
+    }
+
+    @Transactional
+    public BookResponse updateBook(Long bookId, BookUpdateRequest request) {
+        Book updatedBook = bookAdminManager.updateBook(bookId, request);
+        return bookDtoMapper.toBookResp(updatedBook);
+    }
+}

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookService.java
@@ -11,15 +11,6 @@ import com.Familyship.checkkuleogi.domains.book.dto.request.FeedbackOnBookReques
 import java.util.List;
 
 public interface BookService {
-    BookResponse createBook(BookMBTIRequest request);
-    void deleteBookById(Long bookId);
     List<BookResponse> getAllBooks();
-    BookResponse updateBook(Long bookId, BookUpdateRequest request);
-
-
     BookResponse selectBookBy(Long ChildIdx, Long BookIdx);
-    void feedbackOnBook(BookLikeRequest req);
-
-    List<BookCachingItem> getRecentlyViewedBooks(Long childIdx);
-    List<BookCachingItem> getLikedBooks(Long childIdx);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookServiceImpl.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookServiceImpl.java
@@ -1,51 +1,25 @@
 package com.Familyship.checkkuleogi.domains.book.service;
 
-import com.Familyship.checkkuleogi.domains.book.dto.BookCachingItem;
-import com.Familyship.checkkuleogi.domains.book.dto.request.BookLikeRequest;
-import com.Familyship.checkkuleogi.domains.book.dto.request.BookUpdateRequest;
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
+import com.Familyship.checkkuleogi.domains.book.implementation.BookAdminManager;
 import com.Familyship.checkkuleogi.domains.book.implementation.BookManager;
 import com.Familyship.checkkuleogi.domains.book.implementation.mapper.BookDtoMapper;
-import com.Familyship.checkkuleogi.domains.book.implementation.BookAdminManager;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import com.Familyship.checkkuleogi.domains.book.domain.Book;
-import com.Familyship.checkkuleogi.domains.book.dto.request.BookMBTIRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-
 @Service
 @AllArgsConstructor
-public class BookServiceImpl implements BookService {
+public abstract class BookServiceImpl implements BookService {
 
     private final BookDtoMapper bookDtoMapper;
     private final BookManager bookManager;
     private final BookAdminManager bookAdminManager;
 
-    @Override
-    @Transactional
-    public BookResponse createBook(BookMBTIRequest req) {
-        Book book = bookAdminManager.createBook(req);
-        return bookDtoMapper.toBookResp(book);
-    }
-
-    @Override
-    @Transactional
-    public void deleteBookById(Long bookId) {
-        bookAdminManager.deleteBook(bookId);
-    }
-
-    @Override
-    @Transactional
-    public BookResponse updateBook(Long bookId, BookUpdateRequest request) {
-        Book updatedBook = bookAdminManager.updateBook(bookId, request);
-        return bookDtoMapper.toBookResp(updatedBook);
-    }
-
-    @Override
     @Transactional(readOnly = true)
     public List<BookResponse> getAllBooks() {
         List<Book> books = bookAdminManager.getAllBooks();
@@ -54,25 +28,9 @@ public class BookServiceImpl implements BookService {
                 .collect(Collectors.toList());
     }
 
-    @Override
     @Transactional(readOnly = true)
     public BookResponse selectBookBy(Long childIdx, Long bookIdx) {
         Book book = bookManager.selectBookBy(childIdx, bookIdx);
         return bookDtoMapper.toBookResp(book);
-    }
-
-    @Override
-    public void feedbackOnBook(BookLikeRequest req) {
-        bookManager.feedbackOnBook(req);
-    }
-
-    @Override
-    public List<BookCachingItem> getRecentlyViewedBooks(Long childIdx) {
-        return bookManager.getRecentlyViewedBooks(childIdx);
-    }
-
-    @Override
-    public List<BookCachingItem> getLikedBooks(Long childIdx) {
-        return List.of();
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookUserService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookUserService.java
@@ -1,0 +1,44 @@
+package com.Familyship.checkkuleogi.domains.book.service;
+
+import com.Familyship.checkkuleogi.domains.book.domain.Book;
+import com.Familyship.checkkuleogi.domains.book.dto.BookCachingItem;
+import com.Familyship.checkkuleogi.domains.book.dto.request.BookLikeRequest;
+import com.Familyship.checkkuleogi.domains.book.dto.request.BookMBTIRequest;
+import com.Familyship.checkkuleogi.domains.book.dto.request.BookUpdateRequest;
+import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
+import com.Familyship.checkkuleogi.domains.book.implementation.BookAdminManager;
+import com.Familyship.checkkuleogi.domains.book.implementation.BookManager;
+import com.Familyship.checkkuleogi.domains.book.implementation.mapper.BookDtoMapper;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BookUserService extends BookServiceImpl {
+
+    private BookDtoMapper bookDtoMapper;
+    private BookManager bookManager;
+    private BookAdminManager bookAdminManager;
+
+    public BookUserService(BookDtoMapper bookDtoMapper, BookManager bookManager, BookAdminManager bookAdminManager) {
+        super(bookDtoMapper, bookManager, bookAdminManager);
+    }
+
+    @Transactional(readOnly = true)
+    public void feedbackOnBook(BookLikeRequest req) {
+        bookManager.feedbackOnBook(req);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookCachingItem> getRecentlyViewedBooks(Long childIdx) {
+        return bookManager.getRecentlyViewedBooks(childIdx);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookCachingItem> getLikedBooks(Long childIdx) {
+        return List.of();
+    }
+}


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - BookService를 BookAdminService와 BookUserService로 수평 확장한 뒤, 이 둘의 상위계층을 만들려고 했으나 멘토 지도 후 차후 상황에 따라 다시 고려하는 것으로 결정

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 비즈니스 로직은, 우리가 '무엇을 보여줄지'에 대한 고민으로 기준을 세운다.
    - 결국 캡슐화되지않은, 메서드 시그니처를 통해 해당 비즈니스가 어떤 기능을 수생해줄지 추상화를 통해 외부에 드러내는 곳이다.
    - 추후에 더 공부해서 기준 세우기 TODO

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
