### PR TITLE
[feature/kkuleogi-28] 오프라인 배치 방식 책 추천 목록 API ( + CACHE HIT ! )

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/dto/BookCachingItem.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/dto/BookCachingItem.java
@@ -1,3 +1,4 @@
 package com.Familyship.checkkuleogi.domains.book.dto;
 
 public record BookCachingItem(Long idx, String title, String author, String publisher, String summary, String content, String mbti, Boolean isLike) {}
+

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
@@ -3,7 +3,6 @@ package com.Familyship.checkkuleogi.domains.book.implementation;
 import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.book.domain.repository.BookRepository;
 import com.Familyship.checkkuleogi.domains.book.dto.BookCachingItem;
-import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
 import com.Familyship.checkkuleogi.domains.book.exception.BookException;
 import com.Familyship.checkkuleogi.domains.book.exception.BookExceptionType;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
@@ -153,8 +152,8 @@ public class BookCacheManager {
         }
     }
 
-    public BookResponse convertToBookResp(BookCachingItem cachedBook) {
-        return new BookResponse(
+    public BookCachingItem convertToBookCachingItem(BookCachingItem cachedBook) {
+        return new BookCachingItem(
                 cachedBook.idx(),
                 cachedBook.title(),
                 cachedBook.author(),

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookManager.java
@@ -4,24 +4,18 @@ import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.book.domain.repository.BookRepository;
 import com.Familyship.checkkuleogi.domains.book.dto.BookCachingItem;
 import com.Familyship.checkkuleogi.domains.book.dto.request.BookLikeRequest;
-import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
 import com.Familyship.checkkuleogi.domains.book.exception.BookException;
 import com.Familyship.checkkuleogi.domains.book.exception.BookExceptionType;
 import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.domains.child.implementation.ChildManager;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import com.Familyship.checkkuleogi.domains.like.domain.repository.BookLikeRepository;
-import com.Familyship.checkkuleogi.global.domain.exception.NotFoundException;
-import com.Familyship.checkkuleogi.security.jwt.JwtProvider;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Component
@@ -33,13 +27,13 @@ public class BookManager {
     private final ChildManager childManager;
     private final BookCacheManager bookCacheManager;
 
-    public BookResponse selectBookBy(Long childIdx, Long bookIdx) {
+    public BookCachingItem getBook(Long childIdx, Long bookIdx) {
         // 캐시에서 먼저 조회 (캐시에 없을 경우 DB에서 조회하여 캐시에 저장)
         BookCachingItem cachedBook = bookCacheManager.findBookFromCacheOrDB(childIdx, bookIdx);
 
         // 최근 본 책 목록에 해당 책 추가
         bookCacheManager.cacheRecentlyViewedBook(cachedBook, childIdx);
-        return bookCacheManager.convertToBookResp(cachedBook);
+        return bookCacheManager.convertToBookCachingItem(cachedBook);
     }
 
     public List<BookCachingItem> getRecentlyViewedBooks(Long childIdx) {

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookManager.java
@@ -10,6 +10,8 @@ import com.Familyship.checkkuleogi.domains.child.domain.Child;
 import com.Familyship.checkkuleogi.domains.child.implementation.ChildManager;
 import com.Familyship.checkkuleogi.domains.like.domain.BookLike;
 import com.Familyship.checkkuleogi.domains.like.domain.repository.BookLikeRepository;
+import com.Familyship.checkkuleogi.domains.recommend.domain.Recommend;
+import com.Familyship.checkkuleogi.domains.recommend.domain.repository.RecommendRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,7 @@ import java.util.List;
 public class BookManager {
     private final BookRepository bookRepository;
     private final BookLikeRepository bookLikeRepository;
+    private final RecommendRepository recommendRepository;
 
     private final ChildManager childManager;
     private final BookCacheManager bookCacheManager;
@@ -55,6 +58,18 @@ public class BookManager {
             likedBooks.add(cachedBook);
         }
         return likedBooks;
+    }
+
+    public List<BookCachingItem> getRecommendBooks(Long childIdx) {
+        List<Recommend> recommendations = recommendRepository.findByChildIdx(childIdx);
+        List<BookCachingItem> recommendedBooks = new ArrayList<>();
+
+        for (Recommend recommend : recommendations) {
+            // 책 카시에서 메타데이터 검색하기, 없을 경우 DB 조회 후 캐시에 저장
+            BookCachingItem cachedBook = bookCacheManager.findBookFromCacheOrDB(childIdx, recommend.getBookIdx());
+            recommendedBooks.add(cachedBook);
+        }
+        return recommendedBooks;
     }
 
     public void feedbackOnBook(BookLikeRequest req) {

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/presentation/BookController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/presentation/BookController.java
@@ -27,10 +27,9 @@ public class BookController {
         return success(bookService.createBook(req));
     }
 
-    @DeleteMapping("/admin/{bookId}")
-    public CommonResponseEntity<String> deleteBook(@PathVariable Long bookId) {
-        bookService.deleteBookById(bookId);
-        return success("삭제 완료");
+    @GetMapping("")
+    public CommonResponseEntity<List<BookResponse>> getAllBooks() {
+        return success(bookService.getAllBooks());
     }
 
     @PutMapping("/admin/{bookId}")
@@ -38,19 +37,20 @@ public class BookController {
         return success(bookService.updateBook(bookId, request));
     }
 
-    @GetMapping("")
-    public CommonResponseEntity<List<BookResponse>> getAllBooks() {
-        return success(bookService.getAllBooks());
+    @DeleteMapping("/admin/{bookId}")
+    public CommonResponseEntity<String> deleteBook(@PathVariable Long bookId) {
+        bookService.deleteBookById(bookId);
+        return success("삭제 완료");
+    }
+
+    @GetMapping("/{bookIdx}")
+    public CommonResponseEntity<BookCachingItem> getBook(@RequestParam("kidIdx") Long childIdx, @PathVariable Long bookIdx) {
+        return success(bookService.getBook(childIdx, bookIdx));
     }
 
     @GetMapping("/{childIdx}/recent")
     public CommonResponseEntity<List<BookCachingItem>> getRecentlyViewedBooks(@PathVariable Long childIdx) {
         return success(bookService.getRecentlyViewedBooks(childIdx));
-    }
-
-    @GetMapping("/{bookIdx}")
-    public CommonResponseEntity<BookResponse> selectBook(@RequestParam("kidIdx") Long childIdx, @PathVariable Long bookIdx) {
-        return success(bookService.selectBookBy(childIdx, bookIdx));
     }
 
     @PostMapping("/like")

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/presentation/BookController.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/presentation/BookController.java
@@ -53,6 +53,11 @@ public class BookController {
         return success(bookService.getRecentlyViewedBooks(childIdx));
     }
 
+    @GetMapping("/{childIdx}/recommend")
+    public CommonResponseEntity<List<BookCachingItem>> getRecommendBooks(@PathVariable Long childIdx) {
+        return success(bookService.getRecommendBooks(childIdx));
+    }
+
     @PostMapping("/like")
     public CommonResponseEntity<String> feedbackOnBook(@RequestBody BookLikeRequest req) {
         bookService.feedbackOnBook(req);
@@ -63,10 +68,5 @@ public class BookController {
     public CommonResponseEntity<String> cancelFeedbackOnBook(@RequestBody BookLikeRequest req) {
         bookService.cancelFeedbackOnBook(req);
         return success("피드백 삭제 완료");
-    }
-
-    @GetMapping("/{childIdx}/like")
-    public CommonResponseEntity<List<BookCachingItem>> getLikedBooks(@PathVariable Long childIdx) {
-        return success(bookService.getLikedBooks(childIdx));
     }
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookService.java
@@ -16,12 +16,13 @@ public interface BookService {
     List<BookResponse> getAllBooks();
     BookResponse updateBook(Long bookId, BookUpdateRequest request);
 
-
-    // 유저 기능
+    // 유저 기능 (Select, CACHING)
     BookCachingItem getBook(Long ChildIdx, Long BookIdx);
     List<BookCachingItem> getRecentlyViewedBooks(Long childIdx);
     List<BookCachingItem> getLikedBooks(Long childIdx);
+    List<BookCachingItem> getRecommendBooks(Long childIdx);
 
+    // 유저 기능 (Update)
     void feedbackOnBook(BookLikeRequest req);
     void cancelFeedbackOnBook(BookLikeRequest req);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookService.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookService.java
@@ -6,22 +6,22 @@ import com.Familyship.checkkuleogi.domains.book.dto.request.BookLikeRequest;
 import com.Familyship.checkkuleogi.domains.book.dto.request.BookMBTIRequest;
 import com.Familyship.checkkuleogi.domains.book.dto.request.BookUpdateRequest;
 import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
-import com.Familyship.checkkuleogi.domains.book.dto.request.FeedbackOnBookRequest;
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
 
 public interface BookService {
+    // 관리자 기능
     BookResponse createBook(BookMBTIRequest request);
     void deleteBookById(Long bookId);
     List<BookResponse> getAllBooks();
     BookResponse updateBook(Long bookId, BookUpdateRequest request);
 
 
-    BookResponse selectBookBy(Long ChildIdx, Long BookIdx);
-    void feedbackOnBook(BookLikeRequest req);
-    void cancelFeedbackOnBook(BookLikeRequest req);
-
+    // 유저 기능
+    BookCachingItem getBook(Long ChildIdx, Long BookIdx);
     List<BookCachingItem> getRecentlyViewedBooks(Long childIdx);
     List<BookCachingItem> getLikedBooks(Long childIdx);
+
+    void feedbackOnBook(BookLikeRequest req);
+    void cancelFeedbackOnBook(BookLikeRequest req);
 }

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookServiceImpl.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookServiceImpl.java
@@ -7,7 +7,6 @@ import com.Familyship.checkkuleogi.domains.book.dto.response.BookResponse;
 import com.Familyship.checkkuleogi.domains.book.implementation.BookManager;
 import com.Familyship.checkkuleogi.domains.book.implementation.mapper.BookDtoMapper;
 import com.Familyship.checkkuleogi.domains.book.implementation.BookAdminManager;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.Familyship.checkkuleogi.domains.book.domain.Book;
@@ -57,8 +56,8 @@ public class BookServiceImpl implements BookService {
 
     @Override
     @Transactional(readOnly = true)
-    public BookResponse selectBookBy(Long childIdx, Long bookIdx) {
-        return bookManager.selectBookBy(childIdx, bookIdx);
+    public BookCachingItem getBook(Long childIdx, Long bookIdx) {
+        return bookManager.getBook(childIdx, bookIdx);
     }
 
     @Override

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookServiceImpl.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/service/BookServiceImpl.java
@@ -8,6 +8,7 @@ import com.Familyship.checkkuleogi.domains.book.implementation.BookManager;
 import com.Familyship.checkkuleogi.domains.book.implementation.mapper.BookDtoMapper;
 import com.Familyship.checkkuleogi.domains.book.implementation.BookAdminManager;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import com.Familyship.checkkuleogi.domains.book.domain.Book;
 import com.Familyship.checkkuleogi.domains.book.dto.request.BookMBTIRequest;
@@ -16,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
+@Slf4j
 @Service
 @AllArgsConstructor
 public class BookServiceImpl implements BookService {
@@ -61,13 +62,21 @@ public class BookServiceImpl implements BookService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<BookCachingItem> getRecentlyViewedBooks(Long childIdx) {
         return bookManager.getRecentlyViewedBooks(childIdx);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<BookCachingItem> getLikedBooks(Long childIdx) {
         return bookManager.getLikedBooks(childIdx);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BookCachingItem> getRecommendBooks(Long childIdx) {
+        return bookManager.getRecommendBooks(childIdx);
     }
 
     @Override

--- a/src/main/java/com/Familyship/checkkuleogi/domains/recommend/domain/Recommend.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/recommend/domain/Recommend.java
@@ -11,6 +11,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+//@Table(
+//        indexes = {
+//                @Index(name = "recommend", columnList = "childIdx")
+//        })  //추후 Recommend에 속상이 늘어날 시 인덱싱 트레이드오프 계산 필요
 public class Recommend {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - 도서 - '개발자를 위한 레디스'

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 오프라인 배치 방식을 통해 RDB에 영속되어 있는 추천 책목록을 API를 통해 반환해줍니다. 이떄, 해당 책 메타 데이터를 캐싱합니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 최근 본 목록, 좋아요 한 목록 책 목록 캐싱 방법과 달리, 유저-추천목록 리스트 자료구조를 레디스에 만들지 않습니다.
    - 추후 '반응형 추천 시스템'으로 디벨롭할 것을 염두했습니다. 우아한 블로그 글 참고

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
