### PR TITLE
[feature/kkuleogi-30] 관리자 북 업데이트 시 캐시 Book 데이터 동기화 (일관성 보장)

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
@@ -34,25 +34,6 @@ public class BookCacheManager {
     private final BookRepository bookRepository;
     private final BookLikeRepository bookLikeRepository;
 
-
-    public Book findBookBy(Long bookIdx) {
-        return bookRepository.findById(bookIdx)
-                .orElseThrow(() -> new BookException(BookExceptionType.BOOK_NOT_FOUND_EXCEPTION));
-    }
-
-    public List<BookCachingItem> findBookListBy(Long childIdx) {
-        String listKey = RECENTLY_VIEWED_BOOKS_PREFIX + ":" + childIdx;
-        List<BookCachingItem> recentBooks = new ArrayList<>();
-
-        List<String> recentBookIds = redisTemplate.opsForList().range(listKey, 0, -1);
-
-        for (String bookIdx : recentBookIds) {
-            // 2. 각 bookIdx에 대해 글로벌 캐시에서 메타데이터를 가져오거나, 없으면 DB 조회
-            recentBooks.add(findBookFromCacheOrDB(childIdx, Long.valueOf(bookIdx)));
-        }
-        return recentBooks;
-    }
-
     // 책 메타데이터 캐시에서 조회
     public BookCachingItem findBookFromCacheOrDB(Long childIdx, Long bookIdx) {
         String cacheBookKey = BOOK_CACHE_KEY_PREFIX + ":" + bookIdx;
@@ -75,6 +56,32 @@ public class BookCacheManager {
         // `isLike` 필드가 최신 상태로 반영되도록 새로운 객체 생성
         bookCachingItem = updateLikeData(bookCachingItem, likeDislike);
         return bookCachingItem;
+    }
+
+    public void updateBookInCache(Book book) {
+        String cacheBookKey = BOOK_CACHE_KEY_PREFIX + ":" + book.getIdx();
+        try {
+            BookCachingItem bookCachingItem = fromBookToBookCachingItem(book, null);
+            String bookJson = objectMapper.writeValueAsString(bookCachingItem);
+
+            // 캐시에 책 정보를 업데이트
+            redisTemplate.opsForValue().set(cacheBookKey, bookJson, Duration.ofDays(7));
+        } catch (JsonProcessingException e) {
+            throw new BookException(BookExceptionType.BOOK_CACHING_ITEM_CAN_NOT_SERIALIZING);
+        }
+    }
+
+    public List<BookCachingItem> findBookListBy(Long childIdx) {
+        String listKey = RECENTLY_VIEWED_BOOKS_PREFIX + ":" + childIdx;
+        List<BookCachingItem> recentBooks = new ArrayList<>();
+
+        List<String> recentBookIds = redisTemplate.opsForList().range(listKey, 0, -1);
+
+        for (String bookIdx : recentBookIds) {
+            // 2. 각 bookIdx에 대해 글로벌 캐시에서 메타데이터를 가져오거나, 없으면 DB 조회
+            recentBooks.add(findBookFromCacheOrDB(childIdx, Long.valueOf(bookIdx)));
+        }
+        return recentBooks;
     }
 
     public Boolean findLikeFromCacheOrDB(Long childIdx, Long bookIdx) {
@@ -150,6 +157,11 @@ public class BookCacheManager {
         } catch (JsonProcessingException e) {
             throw new BookException(BookExceptionType.BOOK_CACHING_ITEM_CAN_NOT_SERIALIZING);
         }
+    }
+
+    public Book findBookBy(Long bookIdx) {
+        return bookRepository.findById(bookIdx)
+                .orElseThrow(() -> new BookException(BookExceptionType.BOOK_NOT_FOUND_EXCEPTION));
     }
 
     public BookCachingItem convertToBookCachingItem(BookCachingItem cachedBook) {


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - 도서 - '개발자를 위한 레디스'

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 관리자가 북 데이터를 업데이트할 때, Redis에 이전 데이터로 캐싱된 북이 있을 시 동기화해줍니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - Cache Warming도 추후 고려할 수 있음. 인기가 예상되는 베스트셀러 등록 시 미리 캐싱
    - 활동이 활발한 유저들의 추천 책 목록이 갱신되었을 때 미리 캐싱하여 사용자 경험 극대화 
    - 진명인의 API 구현 역할 끝. 배포 준비합니다

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
