### PR TITLE
[feature/kkuleogi-31] 관리자 북 삭제 시 캐시 Book 데이터 동기화 (일관성 보장)

### DIFF
--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookAdminManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookAdminManager.java
@@ -46,6 +46,8 @@ public class BookAdminManager {
     }
 
     public void deleteBook(Long bookId) {
+        //캐시에 삭제 반영
+        bookCacheManager.deleteBookInCache(bookId);
         bookRepository.deleteById(bookId);
     }
 

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
@@ -58,6 +58,11 @@ public class BookCacheManager {
         return bookCachingItem;
     }
 
+    public void deleteBookInCache(Long bookId) {
+        String cacheBookKey = BOOK_CACHE_KEY_PREFIX + ":" + bookId;
+        redisTemplate.delete(cacheBookKey);
+    }
+
     public void updateBookInCache(Book book) {
         String cacheBookKey = BOOK_CACHE_KEY_PREFIX + ":" + book.getIdx();
         try {

--- a/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/book/implementation/BookCacheManager.java
@@ -90,7 +90,6 @@ public class BookCacheManager {
     }
 
     public Boolean findLikeFromCacheOrDB(Long childIdx, Long bookIdx) {
-
         //TODO 추후, 좋아요까지 캐싱할 것인지 한다면 DB에서는 따로 관리안할지 고민필요. 좋아요는 쉽게 update되기 때문에, 현재 동기화 이슈가 있을 수 있음
         /*
         String likeKey = BOOK_LIKE_CACHE_KEY_PREFIX + childIdx + ":" + bookIdx;

--- a/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
+++ b/src/main/java/com/Familyship/checkkuleogi/domains/like/domain/BookLike.java
@@ -25,7 +25,7 @@ public class BookLike extends BaseEntity {
     @JoinColumn(name = "child_idx", referencedColumnName = "child_idx")
     private Child child;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "book_idx", referencedColumnName = "book_idx")
     private Book book;
 


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - 도서 - '개발자를 위한 레디스'

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 관리자가 책 DB에서 물리적 삭제 시, 캐시서버에서도 해당 책이 캐싱되어있다면 삭제
    - Book 데이터가 삭제될 시 관련데이터인 Book_like도 같이 삭제되도록 제약조건 추가
    - API 끝난줄 알았는데 자려고 누웠다가 생각남. 찐막최종 API   배포준비하러 갑니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 위와 같이 테이블 연간관계에서 제약조건들 놓친 부분들이 몇개 있는 것 같습니다. 추후 TODO

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : YES

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
